### PR TITLE
Only selecting a default subtitle in stream in smart mode if it isn't forced or matches audio

### DIFF
--- a/Emby.Server.Implementations/Library/MediaStreamSelector.cs
+++ b/Emby.Server.Implementations/Library/MediaStreamSelector.cs
@@ -64,7 +64,7 @@ namespace Emby.Server.Implementations.Library
                 // If the audio language is one of the user's preferred subtitle languages behave like OnlyForced.
                 if (!preferredLanguages.Contains(audioTrackLanguage, StringComparison.OrdinalIgnoreCase))
                 {
-                    stream = sortedStreams.FirstOrDefault(x => MatchesPreferredLanguage(x.Language, preferredLanguages));
+                    stream = sortedStreams.FirstOrDefault(x => MatchesPreferredLanguage(x.Language, preferredLanguages) && (x.Language == audioTrackLanguage || !x.IsForced));
                 }
                 else
                 {


### PR DESCRIPTION
If a subtitle stream is marked as default and forced, it is only selected in smart mode if the language of the subtitles is the same as the language in the audio.

**Changes**
When selecting a subtitle track in smart mode, checks if the language of the track is the same as the language of the audio track or if it is not forced.

