### PR TITLE
Only match languages if the audio language is defined

### DIFF
--- a/Emby.Server.Implementations/Library/MediaStreamSelector.cs
+++ b/Emby.Server.Implementations/Library/MediaStreamSelector.cs
@@ -64,7 +64,7 @@ namespace Emby.Server.Implementations.Library
                 // If the audio language is one of the user's preferred subtitle languages behave like OnlyForced.
                 if (!preferredLanguages.Contains(audioTrackLanguage, StringComparison.OrdinalIgnoreCase))
                 {
-                    stream = sortedStreams.FirstOrDefault(x => MatchesPreferredLanguage(x.Language, preferredLanguages) && (x.Language == audioTrackLanguage || !x.IsForced));
+                    stream = sortedStreams.FirstOrDefault(x => MatchesPreferredLanguage(x.Language, preferredLanguages) && (x.Language == audioTrackLanguage || !x.IsForced || IsLanguageUndefined(audioTrackLanguage)));
                 }
                 else
                 {


### PR DESCRIPTION
**Changes**
Check if the audio language is defined, and in case it isn't, selecting the subtitle track that had matched.